### PR TITLE
Fix error handling

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -5,6 +5,7 @@ import (
 
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net"
@@ -74,7 +75,7 @@ func (c *conn) Read(b []byte) (int, error) {
 		if err != nil {
 			if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
 				// Ignore timeout error #77
-			} else if err == net.ErrClosed {
+			} else if errors.Is(err, net.ErrClosed) {
 				// Ignore close errors
 			} else {
 				log.Debug.Println("decryption failed:", err)

--- a/server.go
+++ b/server.go
@@ -213,8 +213,8 @@ func (s *Server) listenAndServe(ctx context.Context) error {
 	serverStop := make(chan struct{})
 	go func() {
 		<-serverCtx.Done()
-		ln.Close()
 		s.ss.Close()
+		ln.Close()
 		log.Debug.Println("http server stopped")
 		serverStop <- struct{}{}
 	}()


### PR DESCRIPTION
This code
```go
...
ctx, cancel := context.WithCancel(context.Background())
go func() {
	time.Sleep(time.Second)	
	cancel()
}()

err = server.ListenAndServe(ctx)
if err != nil && !errors.Is(err, http.ErrServerClosed) {
	log.Println(err)
}
...
```
throws false positive errors:
```
conn.go:83: decryption failed: read tcp 192.168.1.2:38891->192.168.1.3:58876: use of closed network connection
conn.go:83: decryption failed: read tcp 192.168.1.2:38891->192.168.1.4:49476: use of closed network connection
accept tcp [::]: 38891: use of closed network connection
```

Thanks.