### PR TITLE
Fix for emitted JSON to be compliant with HomeKit protocol

### DIFF
--- a/characteristic/c.go
+++ b/characteristic/c.go
@@ -257,7 +257,7 @@ func (c *C) MarshalJSON() ([]byte, error) {
 		Permissions []string `json:"perms"`
 		Format      string   `json:"format"`
 
-		Value       *V          `json:"value"`
+		Value       *V          `json:"value,omitempty"`
 		Description string      `json:"description,omitempty"` // manufacturer description (optional)
 		Unit        string      `json:"unit,omitempty"`
 		MaxLen      int         `json:"maxLen,omitempty"`

--- a/characteristic/c.go
+++ b/characteristic/c.go
@@ -257,7 +257,7 @@ func (c *C) MarshalJSON() ([]byte, error) {
 		Permissions []string `json:"perms"`
 		Format      string   `json:"format"`
 
-		Value       *V          `json:"value,omitempty"`
+		Value       *V          `json:"value"`
 		Description string      `json:"description,omitempty"` // manufacturer description (optional)
 		Unit        string      `json:"unit,omitempty"`
 		MaxLen      int         `json:"maxLen,omitempty"`
@@ -287,6 +287,8 @@ func (c *C) MarshalJSON() ([]byte, error) {
 		// 2022-03-21 (mah) FIXME provide a http request instead of nil
 		if v, s := c.ValueRequest(nil); s == 0 {
 			d.Value = &V{v}
+		} else {
+			d.Value = &V{c.Val} // dummy "zero" value
 		}
 	}
 

--- a/characteristic/c_test.go
+++ b/characteristic/c_test.go
@@ -245,4 +245,12 @@ func TestCharacteristicJson(t *testing.T) {
 			t.Fatalf("json-encoded value is of wrong type: is=%v want=%v", is, want)
 		}
 	}
+
+	// special case /identify must not emit any "value"
+	id := NewIdentify().C
+	jsonMap := encodeDecodeJson(id)
+
+	if _, exists := jsonMap["value"]; exists {
+		t.Fatalf("Identify characteristic cannot emit \"value\": %+v", jsonMap)
+	}
 }

--- a/characteristics.go
+++ b/characteristics.go
@@ -12,9 +12,9 @@ import (
 )
 
 type characteristicData struct {
-	Aid   uint64      `json:"aid"`
-	Iid   uint64      `json:"iid"`
-	Value interface{} `json:"value"`
+	Aid   uint64            `json:"aid"`
+	Iid   uint64            `json:"iid"`
+	Value *characteristic.V `json:"value,omitempty"`
 
 	// optional values
 	Type        *string     `json:"type,omitempty"`
@@ -88,7 +88,7 @@ func (srv *Server) getCharacteristics(res http.ResponseWriter, req *http.Request
 			err = true
 			cdata.Status = &s
 		} else {
-			cdata.Value = v
+			cdata.Value = &characteristic.V{v}
 		}
 
 		if meta {
@@ -142,6 +142,14 @@ func (srv *Server) getCharacteristics(res http.ResponseWriter, req *http.Request
 	log.Debug.Println(toJSON(resp))
 
 	if err {
+		// when there's an error somewhere, "status: 0" must now be explicit
+		noError := 0
+		for _, c := range arr {
+			if c.Status == nil {
+				c.Status = &noError
+			}
+		}
+
 		JsonMultiStatus(res, resp)
 	} else {
 		JsonOK(res, resp)

--- a/notification.go
+++ b/notification.go
@@ -20,7 +20,7 @@ func sendNotification(a *accessory.A, c *characteristic.C, req *http.Request) er
 			characteristicData{
 				Aid:   a.Id,
 				Iid:   c.Id,
-				Value: c.Val,
+				Value: &characteristic.V{c.Val},
 			},
 		},
 	}


### PR DESCRIPTION
These changes makes sure that characteristics comply with the HomeKit protocol when a characteristic's `ValueRequestFunc` returns an error. This would fix issue #30.

Changes:
- `GET /accessories` must produce a valid `"value"` in the JSON, even if an error is returned
- a Multi-Status 207 Response must explicitly contain `"status": 0` for successful reads, when there are mixed statuses

One thing to note that deviates from the preliminary patch in #30 is that the `Value` must be tri-state to allow for it to:
- contains a value
- be omitted completely
- and also to be `null`

So I re-used a pattern that was already in the code, using the `V` struct. A `null` value is required because the `ProgrammableSwitchEvent` needs to read as `null`, and the test was failing. I also realized that `/identify` must not emit a value at all.

Also added tests for the changes.

