### PR TITLE
Disable TCP keepalives to avoid constantly waking iOS devices

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -14,6 +14,11 @@ func (ln *listener) Accept() (con net.Conn, err error) {
 		return
 	}
 
+	// disable TCP keepalives
+	if tcpconn, ok := con.(*net.TCPConn); ok {
+		tcpconn.SetKeepAlive(false)
+	}
+
 	conn := newConn(con)
 	setConn(conn.RemoteAddr().String(), conn)
 


### PR DESCRIPTION
I noticed that my iPhone battery life has been quite bad after deploying a HAP server, and under Battery Settings during an idle period it says "Home - 100%". Running `tcpdump` shows that after the initial connection, Linux starts sending TCP keepalives every 15s or so, and the phone always answers. I believe this is keeping the phone (and also my iPad) awake.

HAP specifications section 6.2.3 also mentions this case specifically:
> • HAP accessory servers must not use keepalive messages, which periodically wake up iOS devices.

This patch prevents keepalives from being sent out, and I've verified that it's quiet now when there's no changes/updates to HAP states.