### PR TITLE
Implement WriteResponse characteristics

### DIFF
--- a/characteristic/c.go
+++ b/characteristic/c.go
@@ -245,6 +245,18 @@ func (c *C) RequiresTimedWrite() bool {
 	return false
 }
 
+// IsWriteResponse returns true if the value can
+// return a response on write
+func (c *C) IsWriteResponse() bool {
+	for _, p := range c.Permissions {
+		if p == PermissionWriteResponse {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsObservable returns true if clients are allowed
 // to observe the value of the characteristic.
 func (c *C) IsObservable() bool {

--- a/characteristics.go
+++ b/characteristics.go
@@ -222,8 +222,12 @@ func (srv *Server) putCharacteristics(res http.ResponseWriter, req *http.Request
 			cdata.Status = &status
 		}
 
-		if d.Response != nil && value != nil {
+		if (d.Response != nil || c.IsWriteResponse()) && value != nil {
 			cdata.Value = value
+
+			if c.IsWriteResponse() {
+				cdata.Status = &status
+			}
 		}
 
 		if d.Events != nil {


### PR DESCRIPTION
Some control points require that the response be returned after a write, as opposed to write-then-read. 

If the `SetValueRequestFunc` returns a value and has the WriteResponse permission, then the response is relayed back to the client on return. Status code must be explicitly returned in this case, via a MultiStatus return.