### PR TITLE
use correct content-type for /pairings

### DIFF
--- a/server.go
+++ b/server.go
@@ -139,6 +139,7 @@ func NewServer(store Store, a *accessory.A, as ...*accessory.A) (*Server, error)
 		r.Post("/pair-setup", s.pairSetup)
 		r.Post("/pair-verify", s.pairVerify)
 		r.Post("/identify", s.identify)
+		r.Post("/pairings", s.pairings)
 	})
 
 	// The json encoded content is encrypted. The encryption keys
@@ -149,7 +150,6 @@ func NewServer(store Store, a *accessory.A, as ...*accessory.A) (*Server, error)
 		r.Get("/characteristics", s.getCharacteristics)
 		r.Put("/characteristics", s.putCharacteristics)
 		r.Put("/prepare", s.prepareCharacteristics)
-		r.Post("/pairings", s.pairings)
 	})
 
 	return s, nil


### PR DESCRIPTION
HomeKit expects an application/pairing+tlv8 content type for responses from /pairings, and fails to add the accessory if it gets something different.

You can reproduce the error by attempting to add an accessory as a user who is an admin but not the owner of the home. This will result in a flow that will attempt to use the AddPairing method. On all my devices this fails unless the content type is application/pairing+tlv8.