### PR TITLE
fix: wrong bytes written for conn when encrypting

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -60,9 +60,15 @@ func (c *conn) Write(b []byte) (int, error) {
 	}
 
 	encB, err := ioutil.ReadAll(enc)
-	n, err := c.Conn.Write(encB)
+	if err != nil {
+		return 0, err
+	}
+	_, err = c.Conn.Write(encB)
+	if err != nil {
+		return 0, err
+	}
 
-	return n, err
+	return len(b), nil
 }
 
 const (


### PR DESCRIPTION
conn's Write method returns the wrong number of bytes written when encryption is used. This is unnoticeable when the response is less than 4096 bytes but I encountered a panic when I was implementing `/resource` for snapshots from cameras. The panic was in `bufio.Writer` with the following stack trace.
```
2023/12/25 17:27:50 http: panic serving 192.168.107.191:50535: runtime error: slice bounds out of range [29400:28878]
goroutine 43 [running]:
net/http.(*conn).serve.func1()
        /home/dev/.go/src/net/http/server.go:1868 +0xb9
panic({0x812f60?, 0xc000028108?})
        /home/dev/.go/src/runtime/panic.go:920 +0x270
bufio.(*Writer).Write(0xc00043cc40, {0xc0002f6000?, 0x840139?, 0x4?})
        /home/dev/.go/src/bufio/bufio.go:689 +0x1aa
net/http.(*chunkWriter).Write(0xc0002c4040, {0xc0002f6000, 0x8000, 0x8000})
        /home/dev/.go/src/net/http/server.go:388 +0x106
bufio.(*Writer).Write(0xc0002b6300, {0xc0002f6000?, 0xc0002f6000?, 0x87?})
        /home/dev/.go/src/bufio/bufio.go:682 +0xea
net/http.(*response).write(0xc0002c4000, 0x8000, {0xc0002f6000, 0x8000, 0x8000}, {0x0, 0x0})
        /home/dev/.go/src/net/http/server.go:1648 +0x22a
net/http.(*response).Write(0xc0002b7ec0?, {0xc0002f6000?, 0x8000?, 0x8000?})
        /home/dev/.go/src/net/http/server.go:1606 +0x2a
io.copyBuffer({0x8e0940, 0xc0005107f0}, {0x8e0140, 0xc00030ad50}, {0xc0002f6000, 0x8000, 0x8000})
        /home/dev/.go/src/io/io.go:432 +0x1f4
io.CopyBuffer({0x8e0940?, 0xc0005107f0?}, {0x8e0140?, 0xc00030ad50?}, {0xc0002f6000?, 0x30?, 0x30?})
        /home/dev/.go/src/io/io.go:403 +0x36
net/http.(*response).ReadFrom(0xc0002c4000, {0x8e0140?, 0xc00030ad50})
        /home/dev/.go/src/net/http/server.go:588 +0x3f0
github.com/go-chi/chi/middleware.(*httpFancyWriter).ReadFrom(0xc0002b6380, {0x8e0140, 0xc00030ad50})
        /home/dev/go/pkg/mod/github.com/go-chi/chi@v1.5.4/middleware/wrap_writer.go:137 +0xa3
io.copyBuffer({0x7f4258153ed8, 0xc0002b6380}, {0x8e0140, 0xc00030ad50}, {0xc0002e1800, 0x400, 0x400})
        /home/dev/.go/src/io/io.go:416 +0x147
io.CopyBuffer({0x7f4258153ed8?, 0xc0002b6380?}, {0x8e0140?, 0xc00030ad50?}, {0xc0002e1800?, 0x10?, 0x10?})
        /home/dev/.go/src/io/io.go:403 +0x36
main.main.func1({0x7f4258150cf8, 0xc0002b6380}, 0xc00010a800)
        /home/dev/tmp/hkplay/main.go:77 +0x4d2
net/http.HandlerFunc.ServeHTTP(0x7c7bc0?, {0x7f4258150cf8?, 0xc0002b6380?}, 0xc000325cb5?)
        /home/dev/.go/src/net/http/server.go:2136 +0x29
github.com/go-chi/chi.(*Mux).routeHTTP(0xc0000ac540, {0x7f4258150cf8, 0xc0002b6380}, 0xc00010a800)
        /home/dev/go/pkg/mod/github.com/go-chi/chi@v1.5.4/mux.go:436 +0x1f4
net/http.HandlerFunc.ServeHTTP(0xc00010a700?, {0x7f4258150cf8?, 0xc0002b6380?}, 0x30?)
        /home/dev/.go/src/net/http/server.go:2136 +0x29
github.com/brutella/hap.NewServer.RequestLogger.func3.1({0x8e2fb0, 0xc0002c4000}, 0xc00010a700)
        /home/dev/go/pkg/mod/github.com/go-chi/chi@v1.5.4/middleware/logger.go:57 +0x16d
net/http.HandlerFunc.ServeHTTP(0x8e38c8?, {0x8e2fb0?, 0xc0002c4000?}, 0xb64f40?)
        /home/dev/.go/src/net/http/server.go:2136 +0x29
github.com/go-chi/chi.(*Mux).ServeHTTP(0xc0000ac540, {0x8e2fb0, 0xc0002c4000}, 0xc00010a600)
        /home/dev/go/pkg/mod/github.com/go-chi/chi@v1.5.4/mux.go:87 +0x331
net/http.serverHandler.ServeHTTP({0x8e1bb8?}, {0x8e2fb0?, 0xc0002c4000?}, 0x6?)
        /home/dev/.go/src/net/http/server.go:2938 +0x8e
net/http.(*conn).serve(0xc000262870, {0x8e3890, 0xc000189290})
        /home/dev/.go/src/net/http/server.go:2009 +0x5f4
created by net/http.(*Server).Serve in goroutine 1
        /home/dev/.go/src/net/http/server.go:3086 +0x5cb
```

