### PR TITLE
Fix struct encoding issues

### DIFF
--- a/tlv8/encoder.go
+++ b/tlv8/encoder.go
@@ -3,6 +3,7 @@ package tlv8
 import (
 	"bytes"
 	"reflect"
+	"strings"
 
 	"github.com/xiam/to"
 )
@@ -58,7 +59,8 @@ func structPayload(v interface{}) ([]byte, error) {
 
 	for i := 0; i < vType.NumField(); i++ {
 		if tlv8, ok := vType.Field(i).Tag.Lookup("tlv8"); ok {
-			tag := uint8(to.Uint64(tlv8))
+			values := strings.Split(tlv8, ",")
+			tag := uint8(to.Uint64(values[0]))
 			field := vValue.Field(i)
 			switch v := field.Interface().(type) {
 			case uint8:

--- a/tlv8/encoder.go
+++ b/tlv8/encoder.go
@@ -87,6 +87,9 @@ func structPayload(v interface{}) ([]byte, error) {
 				wr.writeBool(tag, v)
 			default:
 				vValue := reflect.ValueOf(v)
+				if vValue.IsZero() {
+					continue
+				}
 				if vValue.Kind() == reflect.Slice {
 					for i := 0; i < vValue.Len(); i++ {
 						eValue := vValue.Index(i)


### PR DESCRIPTION
Before this change:

1 - Marking a struct field as 'optional' would result in an invalid TLV8 object on encoding, with the tag value set to zero.
2 - A nil field in the encoding structure caused a panic, instead of skipping the field.

To fix these:

1 - The parsing logic from decoder.go was copied to separate tag value from the flag 'optional'.
2 - An IsZero check is added on field values (signifying nil/default value) and so skipped from encoding.
